### PR TITLE
Support for multiple findBetween matches

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,17 +20,37 @@ export function randomString(length) {
   return res;
 }
 
-export function findBetween(content, left, right) {
-  let start = content.indexOf(left);
-  if (start === -1) {
-    return '';
+export function findBetween(content, left, right, repeat = false) {
+  const extracted = [];
+  let doSearch = true;
+  let start, end = 0;
+  
+  while (doSearch) {
+    start = content.indexOf(left);
+    if (start == -1) {
+      break; // no more matches
+    }
+
+    start += left.length;
+    end = content.indexOf(right, start);
+    if (end == -1) {
+      break; // no more matches
+    }
+    let extractedContent = content.substring(start, end);
+
+    // stop here if only extracting one match (default behavior)
+    if (!repeat) {
+      return extractedContent; 
+    }
+
+    // otherwise, add it to the array
+    extracted.push(extractedContent);
+    
+    // update the "cursor" position to the end of the previous match
+    content = content.substring(end + right.length);
   }
-  start += left.length;
-  const end = content.indexOf(right, start);
-  if (end === -1) {
-    return '';
-  }
-  return content.substring(start, end);
+
+  return extracted.length ? extracted : null; // return all matches as an array or null
 }
 
 export function normalDistributionStages(maxVus, durationSeconds, numberOfStages=10) {

--- a/tests/findBetween.js
+++ b/tests/findBetween.js
@@ -7,19 +7,22 @@ export const options = {
   iterations: 1,
   thresholds: {
     checks: ['rate==1.00'],
-  }  
+  }
 }
-
 
 export default function main() {
+  const content = '<html><div>Value 1</div><div>Value 2</div><div>Value 3</div></html>';
+  const divsOnly = '<div>Value 1</div><div>Value 2</div><div>Value 3</div>';
 
   check(null, {
-    'simple': () => findBetween('some text {{data}} XX', '{{', '}}') === "data",
-    'double': () => findBetween('some text {{data1}} {{data2}} XX', '{{', '}}') === "data1",
-    'messy': () => findBetween('let token="secret token";', 'token="', '"') === "secret token",
-    'exact': () => findBetween('**a**', '**', '**') === "a",
-    'no match': () => findBetween('some text', '{{', '}}') === "",
+    'single':                   () => findBetween(content, '<div>', '</div>') === "Value 1",
+    'repeat':                   () => findBetween(content, '<div>', '</div>', true).length === 3,
+    'single-with-repeat':       () => findBetween(content, '<html>', '</html>', true) == divsOnly,
+    'single-with-repeat-array': () => findBetween(content, '<html>', '</html>', true)[0] == divsOnly,
+    'no-match-left':            () => findBetween(content, '<nodiv>', '</div>') === null,
+    'no-match-right':           () => findBetween(content, '<div>', '</nodiv>') === null,
+    'no-match-both':            () => findBetween(content, '<nodiv>', '</nodiv>') === null,
+    'messy':                    () => findBetween('let token="secret token";', 'token="', '"') === "secret token",
+    'exact':                    () => findBetween('**a**', '**', '**') === "a",
   });
-
 }
-


### PR DESCRIPTION
This PR adds a `repeat` optional boolean (defaults to `false`) that allows `findBetween` to search for and extract all matches in the given string instead of just the first match. See `tests\findBetween.js` for examples.