### PR TITLE
build: pin package manager and disable automatic install-time lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -1,37 +1,38 @@
 {
-    "name": "k6-jslib-utils",
-    "repository": "https://github.com/grafana/k6-jslib-utils",
-    "version": "1.3.0",
-    "main": "src/index.js",
-    "devDependencies": {
-        "@babel/core": "7.29.0",
-        "@babel/plugin-transform-block-scoping": "7.28.6",
-        "@babel/preset-env": "7.29.2",
-        "@types/k6": "0.57.1",
-        "@types/webpack": "5.28.5",
-        "babel-loader": "8.4.1",
-        "clean-webpack-plugin": "4.0.0",
-        "husky": "9.1.7",
-        "lint-staged": "12.5.0",
-        "prettier": "3.8.3",
-        "terser-webpack-plugin": "5.5.0",
-        "ts-loader": "9.5.7",
-        "webpack": "5.106.2",
-        "webpack-cli": "7.0.2",
-        "webpack-glob-entries": "1.0.1"
-    },
-    "engines": {},
-    "scripts": {
-        "webpack": "webpack",
-        "test": "k6 run tests/",
-        "prepare": "husky"
-    },
-    "keywords": [
-        "k6"
-    ],
-    "author": "k6 team",
-    "license": "MIT",
-    "lint-staged": {
-        "**/*": "prettier --write --ignore-unknown"
-    }
+  "name": "k6-jslib-utils",
+  "repository": "https://github.com/grafana/k6-jslib-utils",
+  "version": "1.3.0",
+  "packageManager": "npm@10.9.2",
+  "main": "src/index.js",
+  "devDependencies": {
+    "@babel/core": "7.29.0",
+    "@babel/plugin-transform-block-scoping": "7.28.6",
+    "@babel/preset-env": "7.29.2",
+    "@types/k6": "0.57.1",
+    "@types/webpack": "5.28.5",
+    "babel-loader": "8.4.1",
+    "clean-webpack-plugin": "4.0.0",
+    "husky": "9.1.7",
+    "lint-staged": "12.5.0",
+    "prettier": "3.8.3",
+    "terser-webpack-plugin": "5.5.0",
+    "ts-loader": "9.5.7",
+    "webpack": "5.106.2",
+    "webpack-cli": "7.0.2",
+    "webpack-glob-entries": "1.0.1"
+  },
+  "engines": {},
+  "scripts": {
+    "webpack": "webpack",
+    "test": "k6 run tests/",
+    "prepare": "husky"
+  },
+  "keywords": [
+    "k6"
+  ],
+  "author": "k6 team",
+  "license": "MIT",
+  "lint-staged": {
+    "**/*": "prettier --write --ignore-unknown"
+  }
 }


### PR DESCRIPTION
Disables automatic execution of npm/yarn install-time lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`, ...) so a malicious or compromised transitive dependency cannot run arbitrary code during `npm install` / `yarn install`. Manually invoked scripts (`npm run ...`, `yarn ...`) are unaffected — only auto-execution at install time is blocked.

Writes all three package-manager config files at the repo root, regardless of which manager the repo currently uses. Defense in depth: each file is read only by its own tool, so writing all three costs nothing and guards against npm, Yarn Classic, and Yarn Berry equally.
- `.npmrc` → `ignore-scripts=true` (npm, also honored by Yarn Classic)
- `.yarnrc` → `ignore-scripts true` (Yarn Classic, explicit)
- `.yarnrc.yml` → `enableScripts: false` (Yarn Berry; does not read `.npmrc`)

Pins the package manager via `packageManager` in `package.json` so Corepack uses a known version.